### PR TITLE
Add support for `// @modules-ignore-next-line` annotation

### DIFF
--- a/src/DocReader/DocReader.php
+++ b/src/DocReader/DocReader.php
@@ -21,6 +21,7 @@ class DocReader
         if ($phpdoc === null) {
             return false;
         }
+        $phpdoc = $this->prepare($phpdoc);
         $lexer = new Lexer();
         $constExprParser = new ConstExprParser();
         $phpDocParser = new PhpDocParser(new TypeParser($constExprParser), $constExprParser);
@@ -31,11 +32,12 @@ class DocReader
         return count($phpDocNode->getTagsByName('@public')) > 0;
     }
 
-    public function isIgnoredImport(?string $phpdoc):bool
+    public function isIgnoredImport(?string $phpdoc): bool
     {
         if ($phpdoc === null) {
             return false;
         }
+        $phpdoc = $this->prepare($phpdoc);
         try {
             $lexer = new Lexer();
             $constExprParser = new ConstExprParser();
@@ -48,6 +50,23 @@ class DocReader
         } catch (ParserException $e) {
             return false;
         }
+    }
+
+    private function prepare(string $phpdoc): string
+    {
+        if (str_starts_with($phpdoc, '/**')) {
+            return $phpdoc;
+        }
+        if (str_starts_with($phpdoc, '//')) {
+            $lines = explode("\n", $phpdoc);
+            $result = '/**' . PHP_EOL;
+            foreach ($lines as $line) {
+                $result .= ' * ' . ltrim($line, '/ ') . PHP_EOL;
+            }
+            $result .= ' */';
+            return $result;
+        }
+        return $phpdoc;
     }
 
 }

--- a/src/Lib/Internal/DefinitionsGatherer.php
+++ b/src/Lib/Internal/DefinitionsGatherer.php
@@ -56,8 +56,17 @@ class DefinitionsGatherer
                 /** @var Importable[] $imports */
                 $imports = [];
                 foreach ($definitionCollector->imports as $import) {
+                    $comment = $import->getDocComment()?->getText();
+                    //Make sure comments starting with `//` are also included
+                    if ($comment === null && count($import->getComments()) > 0) {
+                        $comment = [];
+                        foreach ($import->getComments() as $commentPart) {
+                            $comment[] = $commentPart->getText();
+                        }
+                        $comment = implode("\n", $comment);
+                    }
                     foreach ($import->uses as $use) {
-                        $imports[] = Importable::fromArray($use->name->parts, $import->getDocComment()?->getText());
+                        $imports[] = Importable::fromArray($use->name->parts, $comment);
                     }
                 }
 

--- a/tests/Lib/Analyzer/IgnoreImportAnnotationTest.php
+++ b/tests/Lib/Analyzer/IgnoreImportAnnotationTest.php
@@ -48,4 +48,25 @@ class IgnoreImportAnnotationTest extends AnalyzerTestCase
         $this->assertCount(0, $result->errors);
     }
 
+    public function test_shouldSucceedWithIgnoreImportAnnotation_alternativeSyntax(): void
+    {
+        /* Given */
+        $moduleAClassAFileDefinition = $this->file('App\ModuleA', ['App\ModuleA\ClassA']);
+        $moduleBClassBFileDefinition = $this->file(
+            'App\ModuleB',
+            ['App\ModuleB\ClassB'],
+            [Importable::fromString('App\ModuleA\ClassA', '// @modules-ignore-next-line')]
+        );
+
+        $moduleA = Module::create('App\ModuleA');
+        $moduleB = Module::create('App\ModuleB');
+        $modules = Modules::builder('.')->register([$moduleA, $moduleB]);
+
+        /* When */
+        $result = Analyzer::create($modules, [$moduleAClassAFileDefinition, $moduleBClassBFileDefinition])->analyze();
+
+        /* Then */
+        $this->assertCount(0, $result->errors);
+    }
+
 }


### PR DESCRIPTION
Some formatters will move /** .. */ to their own section in a file by
defeault while leaving inlince // comments alone